### PR TITLE
Wip/multiple backends

### DIFF
--- a/include/core/jcommon.h
+++ b/include/core/jcommon.h
@@ -47,11 +47,19 @@ G_BEGIN_DECLS
 void __attribute__((constructor)) j_init (void);
 void __attribute__((destructor)) j_fini (void);
 
+void j_init_server (gint);
+void j_fini_server (void);
+
 JConfiguration* j_configuration (void);
 
 JBackend* j_object_backend (void);
 JBackend* j_kv_backend (void);
 JBackend* j_db_backend (void);
+
+// JBackend* j_object_backend_hsm (JHsmHints hsmHints);
+// JBackend* j_kv_backend_hsm (JHsmHints hsmHints);
+JBackend* j_object_backend_tier (guint32 tier);
+JBackend* j_kv_backend_tier (guint32 tier);
 
 G_END_DECLS
 

--- a/include/core/jconfiguration.h
+++ b/include/core/jconfiguration.h
@@ -51,13 +51,16 @@ guint32 j_configuration_get_object_server_count (JConfiguration*);
 guint32 j_configuration_get_kv_server_count (JConfiguration*);
 guint32 j_configuration_get_db_server_count (JConfiguration*);
 
-gchar const* j_configuration_get_object_backend (JConfiguration*);
-gchar const* j_configuration_get_object_component (JConfiguration*);
-gchar const* j_configuration_get_object_path (JConfiguration*);
+guint32 j_configuration_get_object_tier_count (JConfiguration* configuration);
+guint32 j_configuration_get_kv_tier_count (JConfiguration* configuration);
 
-gchar const* j_configuration_get_kv_backend (JConfiguration*);
-gchar const* j_configuration_get_kv_component (JConfiguration*);
-gchar const* j_configuration_get_kv_path (JConfiguration*);
+gchar const* j_configuration_get_object_backend (JConfiguration*, gint32);
+gchar const* j_configuration_get_object_component (JConfiguration*, gint32);
+gchar const* j_configuration_get_object_path (JConfiguration*, gint32);
+
+gchar const* j_configuration_get_kv_backend (JConfiguration*, gint32);
+gchar const* j_configuration_get_kv_component (JConfiguration*, gint32);
+gchar const* j_configuration_get_kv_path (JConfiguration*, gint32);
 
 gchar const* j_configuration_get_db_backend (JConfiguration*);
 gchar const* j_configuration_get_db_component (JConfiguration*);

--- a/lib/core/jcommon.c
+++ b/lib/core/jcommon.c
@@ -156,13 +156,13 @@ j_init (void)
 		goto error;
 	}
 
-	object_backend = j_configuration_get_object_backend(common->configuration);
-	object_component = j_configuration_get_object_component(common->configuration);
-	object_path = j_configuration_get_object_path(common->configuration);
+	object_backend = j_configuration_get_object_backend(common->configuration, 0);
+	object_component = j_configuration_get_object_component(common->configuration, 0);
+	object_path = j_configuration_get_object_path(common->configuration, 0);
 
-	kv_backend = j_configuration_get_kv_backend(common->configuration);
-	kv_component = j_configuration_get_kv_component(common->configuration);
-	kv_path = j_configuration_get_kv_path(common->configuration);
+	kv_backend = j_configuration_get_kv_backend(common->configuration, 0);
+	kv_component = j_configuration_get_kv_component(common->configuration, 0);
+	kv_path = j_configuration_get_kv_path(common->configuration, 0);
 
 	db_backend = j_configuration_get_db_backend(common->configuration);
 	db_component = j_configuration_get_db_component(common->configuration);

--- a/lib/core/jcommon.c
+++ b/lib/core/jcommon.c
@@ -54,16 +54,24 @@ struct JCommon
 	 */
 	JConfiguration* configuration;
 
-	JBackend* object_backend;
-	JBackend* kv_backend;
+
+	JBackend** object_backend;
+	JBackend** kv_backend;
 	JBackend* db_backend;
 
-	GModule* object_module;
-	GModule* kv_module;
+
+	GModule** object_module;
+	GModule** kv_module;
 	GModule* db_module;
+
+
+	guint32 object_tier_count;
+	guint32 kv_tier_count;
 };
 
 static JCommon* j_common = NULL;
+
+enum Component{Server, Client};
 
 /**
  * Returns whether JULEA has been initialized.
@@ -121,8 +129,9 @@ j_get_program_name (gchar const* default_name)
  * \param argc A pointer to \c argc.
  * \param argv A pointer to \c argv.
  */
+static
 void
-j_init (void)
+j_init_intern (enum Component component, gint opt_port)
 {
 	JCommon* common;
 	g_autofree gchar* basename = NULL;
@@ -137,6 +146,14 @@ j_init (void)
 	gchar const* db_path;
 
 	if (j_is_initialized())
+	gboolean success_load_backend;
+#ifdef JULEA_DEBUG
+	g_autofree gchar* kv_path_port = NULL;
+	g_autofree gchar* object_path_port = NULL;
+#endif
+	// Server should be able to reinitilaize as Client
+	// initlizatiosn is called on libray load.
+	if (j_is_initialized() && component == Client)
 	{
 		return;
 	}
@@ -151,38 +168,115 @@ j_init (void)
 
 	common->configuration = j_configuration_new();
 
+	common->object_tier_count = j_configuration_get_object_tier_count(common->configuration);
+	common->kv_tier_count = j_configuration_get_kv_tier_count(common->configuration);
+
+	//FIXME memory is reserver for all backenda in client and server but never used in bothe
+	common->object_backend = g_new( JBackend*, common->object_tier_count );
+	common->object_module = g_new( GModule*, common->object_tier_count );
+	common->kv_backend = g_new( JBackend*, common->kv_tier_count );
+	common->kv_module = g_new( GModule*, common->kv_tier_count );
+
+
 	if (common->configuration == NULL)
 	{
 		goto error;
 	}
 
-	object_backend = j_configuration_get_object_backend(common->configuration, 0);
-	object_component = j_configuration_get_object_component(common->configuration, 0);
-	object_path = j_configuration_get_object_path(common->configuration, 0);
-
-	kv_backend = j_configuration_get_kv_backend(common->configuration, 0);
-	kv_component = j_configuration_get_kv_component(common->configuration, 0);
-	kv_path = j_configuration_get_kv_path(common->configuration, 0);
 
 	db_backend = j_configuration_get_db_backend(common->configuration);
 	db_component = j_configuration_get_db_component(common->configuration);
 	db_path = j_configuration_get_db_path(common->configuration);
 
-	if (j_backend_load_client(object_backend, object_component, J_BACKEND_TYPE_OBJECT, &(common->object_module), &(common->object_backend)))
+
+	if(component == Server)
 	{
-		if (common->object_backend == NULL || !j_backend_object_init(common->object_backend, object_path))
+		if (j_backend_load_server(db_backend, db_component, J_BACKEND_TYPE_DB, &(common->db_module), &(common->db_backend)))
 		{
-			g_critical("Could not initialize object backend %s.\n", object_backend);
-			goto error;
+			if (common->db_backend == NULL || !j_backend_db_init(common->db_backend, db_path))
+			{
+				g_critical("Could not initialize db backend %s.\n", db_backend);
+				goto error;
+			}
+		}
+	}
+	if(component == Client)
+	{
+		if (j_backend_load_client(db_backend, db_component, J_BACKEND_TYPE_DB, &(common->db_module), &(common->db_backend)))
+		{
+			if (common->db_backend == NULL || !j_backend_db_init(common->db_backend, db_path))
+			{
+				g_critical("Could not initialize db backend %s.\n", db_backend);
+				goto error;
+			}
 		}
 	}
 
-	if (j_backend_load_client(kv_backend, kv_component, J_BACKEND_TYPE_KV, &(common->kv_module), &(common->kv_backend)))
+	for (guint32 tier = 0; tier < common->object_tier_count; tier++)
 	{
-		if (common->kv_backend == NULL || !j_backend_kv_init(common->kv_backend, kv_path))
+		object_backend = j_configuration_get_object_backend(common->configuration, tier);
+		object_component = j_configuration_get_object_component(common->configuration, tier);
+		object_path = j_configuration_get_object_path(common->configuration, tier);
+
+		if(component == Server)
 		{
-			g_critical("Could not initialize kv backend %s.\n", kv_backend);
-			goto error;
+#ifdef JULEA_DEBUG
+			// Hack to launch multiple server on differnt ports on the same host
+			object_path_port = g_strdup_printf("%s/%d", object_path, opt_port);
+			object_path = object_path_port;
+#endif
+		}
+
+		if(component == Server)
+		{
+			success_load_backend = j_backend_load_server(object_backend, object_component, J_BACKEND_TYPE_OBJECT, &(common->object_module[tier]), &(common->object_backend[tier]));
+		}
+		if(component == Client)
+		{
+			success_load_backend = j_backend_load_client(object_backend, object_component, J_BACKEND_TYPE_OBJECT, &(common->object_module[tier]), &(common->object_backend[tier]));
+		}
+
+		if (success_load_backend)
+		{
+			if (common->object_backend[tier] == NULL || !j_backend_object_init(common->object_backend[tier], object_path))
+			{
+				g_critical("Could not initialize object backend %s.\n", object_backend);
+				goto error;
+			}
+		}
+	}
+
+	for (guint32 tier = 0; tier < common->kv_tier_count; tier++)
+	{
+		kv_backend = j_configuration_get_kv_backend(common->configuration, tier);
+		kv_component = j_configuration_get_kv_component(common->configuration, tier);
+		kv_path = j_configuration_get_kv_path(common->configuration, tier);
+
+		if(component == Server)
+		{
+#ifdef JULEA_DEBUG
+			// Hack to launch multiple server on differnt ports on the same host
+			kv_path_port = g_strdup_printf("%s/%d", kv_path, opt_port);
+			kv_path = kv_path_port;
+#endif
+		}
+
+		if(component == Server)
+		{
+			success_load_backend = j_backend_load_server(kv_backend, kv_component, J_BACKEND_TYPE_KV, &(common->kv_module[tier]), &(common->kv_backend[tier]));
+		}
+		if(component == Client)
+		{
+			success_load_backend = j_backend_load_client(kv_backend, kv_component, J_BACKEND_TYPE_KV, &(common->kv_module[tier]), &(common->kv_backend[tier]));
+		}
+
+		if (success_load_backend )
+		{
+			if (common->kv_backend[tier] == NULL || !j_backend_kv_init(common->kv_backend[tier], kv_path))
+			{
+				g_critical("Could not initialize kv backend %s.\n", kv_backend);
+				goto error;
+			}
 		}
 	}
 
@@ -195,10 +289,13 @@ j_init (void)
 		}
 	}
 
-	j_connection_pool_init(common->configuration);
-	j_distribution_init();
-	j_background_operation_init(0);
-	j_operation_cache_init();
+	if(component == Client)
+	{
+		j_connection_pool_init(common->configuration);
+		j_distribution_init();
+		j_background_operation_init(0);
+		j_operation_cache_init();
+	}
 
 	g_atomic_pointer_set(&j_common, common);
 
@@ -221,11 +318,39 @@ error:
 	g_error("%s: Failed to initialize JULEA.", G_STRLOC);
 }
 
+
+/**
+ * Initializes JULEA as client..
+ *
+ * \param argc A pointer to \c argc.
+ * \param argv A pointer to \c argv.
+ */
+void
+j_init (void)
+{
+	//FIXME port. paramter is not used in Client init
+	j_init_intern(Client, 0);
+}
+
+
+/**
+ * Initializes JULEA as server..
+ *
+ * \param argc A pointer to \c argc.
+ * \param argv A pointer to \c argv.
+ */
+void
+j_init_server (gint opt_port)
+{
+	j_init_intern(Server, opt_port);
+}
+
 /**
  * Shuts down JULEA.
  */
+static
 void
-j_fini (void)
+j_fini_internal (enum Component component)
 {
 	JCommon* common;
 
@@ -236,9 +361,12 @@ j_fini (void)
 
 	j_trace_enter(G_STRFUNC, NULL);
 
-	j_operation_cache_fini();
-	j_background_operation_fini();
-	j_connection_pool_fini();
+	if(component == Client)
+	{
+		j_operation_cache_fini();
+		j_background_operation_fini();
+		j_connection_pool_fini();
+	}
 
 	common = g_atomic_pointer_get(&j_common);
 	g_atomic_pointer_set(&j_common, NULL);
@@ -248,38 +376,73 @@ j_fini (void)
 		j_backend_db_fini(common->db_backend);
 	}
 
-	if (common->kv_backend != NULL)
-	{
-		j_backend_kv_fini(common->kv_backend);
-	}
-
-	if (common->object_backend != NULL)
-	{
-		j_backend_object_fini(common->object_backend);
-	}
-
 	if (common->db_module)
 	{
 		g_module_close(common->db_module);
 	}
 
-	if (common->kv_module)
+	for (guint32 tier = 0; tier < common->object_tier_count; tier++)
 	{
-		g_module_close(common->kv_module);
+		if (common->object_module[tier])
+		{
+			g_module_close(common->object_module[tier]);
+		}
+
+		if (common->object_backend[tier] != NULL)
+		{
+			j_backend_object_fini(common->object_backend[tier]);
+		}
 	}
 
-	if (common->object_module)
+	for (guint32 tier = 0; tier < common->kv_tier_count; tier++)
 	{
-		g_module_close(common->object_module);
+		if (common->kv_backend[tier] != NULL)
+		{
+			j_backend_kv_fini(common->kv_backend[tier]);
+		}
+
+		if (common->kv_module[tier])
+		{
+			g_module_close(common->kv_module[tier]);
+		}
 	}
 
-	j_configuration_unref(common->configuration);
+	g_free(common->object_backend);
+	g_free(common->object_module);
+	g_free(common->kv_backend);
+	g_free(common->kv_module);
+
+
+	if(component == Client)
+	{
+		j_configuration_unref(common->configuration);
+	}
 
 	j_trace_leave(G_STRFUNC);
 
 	j_trace_fini();
 
 	g_slice_free(JCommon, common);
+}
+
+
+/**
+ * Shuts down JULEA.
+ */
+
+void
+j_fini (void)
+{
+	j_fini_internal(Client);
+}
+
+/**
+ * Shuts down JULEA.
+ */
+void
+j_fini_server (void)
+{
+	j_fini_internal(Server);
 }
 
 /* Internal */
@@ -311,7 +474,7 @@ j_configuration (void)
  * \return The object backend.
  */
 JBackend*
-j_object_backend (void)
+j_object_backend_tier (guint32 tier)
 {
 	JCommon* common;
 
@@ -319,7 +482,7 @@ j_object_backend (void)
 
 	common = g_atomic_pointer_get(&j_common);
 
-	return common->object_backend;
+	return common->object_backend[tier];
 }
 
 /**
@@ -330,7 +493,20 @@ j_object_backend (void)
  * \return The kv backend.
  */
 JBackend*
-j_kv_backend (void)
+j_object_backend (void)
+{
+	return j_object_backend_tier(0);
+}
+
+/**
+ * Returns the data backend.
+ *
+ * \private
+ *
+ * \return The data backend.
+ */
+JBackend*
+j_kv_backend_tier (guint32 tier)
 {
 	JCommon* common;
 
@@ -338,7 +514,20 @@ j_kv_backend (void)
 
 	common = g_atomic_pointer_get(&j_common);
 
-	return common->kv_backend;
+	return common->kv_backend[tier];
+}
+
+/**
+ * Returns the data backend.
+ *
+ * \private
+ *
+ * \return The data backend.
+ */
+JBackend*
+j_kv_backend (void)
+{
+	return j_kv_backend_tier(0);
 }
 
 /**

--- a/lib/core/jconfiguration.c
+++ b/lib/core/jconfiguration.c
@@ -39,6 +39,14 @@
  */
 struct JConfiguration
 {
+	/**
+	 * The servers.
+	 * The oder of ther server determines the order in case of distributed data
+	 * objects.
+	 * KV and Object are hash by key/name and distibuted via modul among all
+	 * servers. So changing order is also affecting which server holds wich
+	 * data.
+	 */
 	struct
 	{
 		/**
@@ -73,11 +81,16 @@ struct JConfiguration
 	}
 	servers;
 
-
+	/**
+	 * The backends.
+	 * An array for each backend type is held. The order determines the tier
+	 * level. Level 0 is the fastes so they should be ordered decresing by
+	 * performance.
+	 */
 	struct
 	{
 		/**
-		 * The object configuration.
+		 * A object tier configuration.
 		 */
 		struct Object_backends
 		{
@@ -101,7 +114,7 @@ struct JConfiguration
 		* object;
 
 		/**
-		 * The kv configuration.
+		 * A kv tier configuration.
 		 */
 		struct Kv_backends
 		{
@@ -123,12 +136,12 @@ struct JConfiguration
 		* kv;
 
 		/**
-		 * The number of object backends.
+		 * The number of object backends/tier levels.
 		 */
 		guint32 object_len;
 
 		/**
-		 * The number of kv backends.
+		 * The number of kv backends/tier levels..
 		 */
 		guint32 kv_len;
 	}
@@ -323,11 +336,13 @@ j_configuration_new_for_data (GKeyFile* key_file)
 	    || kv_backend == NULL
 	    || kv_component == NULL
 	    || kv_path == NULL
-		|| ((object_backend_length != object_component_length) && (object_component_length != object_path_length))
-		|| ((kv_backend_length != kv_component_length) && (kv_component_length != kv_path_length)))
-	    || db_backend == NULL
-	    || db_component == NULL
-	    || db_path == NULL)
+		|| db_backend == NULL
+		|| db_component == NULL
+		|| db_path == NULL
+		|| ((object_backend_length != object_component_length) &&
+		 	(object_component_length != object_path_length))
+		|| ((kv_backend_length != kv_component_length) &&
+			(kv_component_length != kv_path_length)))
 	{
 		g_free(db_backend);
 		g_free(db_component);
@@ -448,7 +463,7 @@ j_configuration_unref (JConfiguration* configuration)
 		g_free(configuration->db.backend);
 		g_free(configuration->db.component);
 		g_free(configuration->db.path);
-		
+
 		g_strfreev(configuration->servers.object);
 		g_strfreev(configuration->servers.kv);
 		g_strfreev(configuration->servers.db);
@@ -501,6 +516,7 @@ j_configuration_get_kv_server_count (JConfiguration* configuration)
 }
 
 guint32
+
 j_configuration_get_db_server_count (JConfiguration* configuration)
 {
 	g_return_val_if_fail(configuration != NULL, 0);
@@ -508,52 +524,70 @@ j_configuration_get_db_server_count (JConfiguration* configuration)
 	return configuration->servers.db_len;
 }
 
+guint32
+j_configuration_get_object_tier_count (JConfiguration* configuration)
+{
+	g_return_val_if_fail(configuration != NULL, 0);
+
+	return configuration->backends.object_len;
+}
+
+guint32
+j_configuration_get_kv_tier_count (JConfiguration* configuration)
+{
+	g_return_val_if_fail(configuration != NULL, 0);
+
+	return configuration->backends.kv_len;
+}
+
+
+
 gchar const*
-j_configuration_get_object_backend (JConfiguration* configuration)
+j_configuration_get_object_backend (JConfiguration* configuration, gint32 tier)
 {
 	g_return_val_if_fail(configuration != NULL, NULL);
 
-	return configuration->backends.object[0].backend;
+	return configuration->backends.object[tier].backend;
 }
 
 gchar const*
-j_configuration_get_object_component (JConfiguration* configuration)
+j_configuration_get_object_component (JConfiguration* configuration, gint32 tier)
 {
 	g_return_val_if_fail(configuration != NULL, NULL);
 
-	return configuration->backends.object[0].component;
+	return configuration->backends.object[tier].component;
 }
 
 gchar const*
-j_configuration_get_object_path (JConfiguration* configuration)
+j_configuration_get_object_path (JConfiguration* configuration, gint32 tier)
 {
 	g_return_val_if_fail(configuration != NULL, NULL);
 
-	return configuration->backends.object[0].path;
+	return configuration->backends.object[tier].path;
 }
 
 gchar const*
-j_configuration_get_kv_backend (JConfiguration* configuration)
+j_configuration_get_kv_backend (JConfiguration* configuration, gint32 tier)
 {
 	g_return_val_if_fail(configuration != NULL, NULL);
 
-	return configuration->backends.kv[0].backend;
+	return configuration->backends.kv[tier].backend;
 }
 
 gchar const*
-j_configuration_get_kv_component (JConfiguration* configuration)
+j_configuration_get_kv_component (JConfiguration* configuration, gint32 tier)
 {
 	g_return_val_if_fail(configuration != NULL, NULL);
 
-	return configuration->backends.kv[0].component;
+	return configuration->backends.kv[tier].component;
 }
 
 gchar const*
-j_configuration_get_kv_path (JConfiguration* configuration)
+j_configuration_get_kv_path (JConfiguration* configuration, gint32 tier)
 {
 	g_return_val_if_fail(configuration != NULL, NULL);
 
-	return configuration->backends.kv[0].path;
+	return configuration->backends.kv[tier].path;
 }
 
 gchar const*

--- a/server/server.c
+++ b/server/server.c
@@ -881,13 +881,13 @@ main (int argc, char** argv)
 
 	port_str = g_strdup_printf("%d", opt_port);
 
-	object_backend = j_configuration_get_object_backend(jd_configuration);
-	object_component = j_configuration_get_object_component(jd_configuration);
-	object_path = j_helper_str_replace(j_configuration_get_object_path(jd_configuration), "{PORT}", port_str);
+	object_backend = j_configuration_get_object_backend(jd_configuration, 0);
+	object_component = j_configuration_get_object_component(jd_configuration, 0);
+	object_path = j_helper_str_replace(j_configuration_get_object_path(jd_configuration, 0), "{PORT}", port_str);
 
-	kv_backend = j_configuration_get_kv_backend(jd_configuration);
-	kv_component = j_configuration_get_kv_component(jd_configuration);
-	kv_path = j_helper_str_replace(j_configuration_get_kv_path(jd_configuration), "{PORT}", port_str);
+	kv_backend = j_configuration_get_kv_backend(jd_configuration, 0);
+	kv_component = j_configuration_get_kv_component(jd_configuration, 0);
+	kv_path = j_helper_str_replace(j_configuration_get_kv_path(jd_configuration, 0), "{PORT}", port_str);
 
 	db_backend = j_configuration_get_db_backend(jd_configuration);
 	db_component = j_configuration_get_db_component(jd_configuration);

--- a/test/configuration.c
+++ b/test/configuration.c
@@ -78,6 +78,11 @@ test_configuration_get (void)
 	gchar const* kv_servers[] = { "localhost", NULL };
 	gchar const* db_servers[] = { "localhost", "host.local", NULL };
 
+
+	gchar const* kv_backends[] = { "null2", "null3", NULL };
+	gchar const* kv_components[] = { "client", "server", NULL };
+	gchar const* kv_paths[] = { "NULL2", "NULL3", NULL };
+
 	key_file = g_key_file_new();
 	g_key_file_set_string_list(key_file, "servers", "object", object_servers, 2);
 	g_key_file_set_string_list(key_file, "servers", "kv", kv_servers, 1);
@@ -85,12 +90,12 @@ test_configuration_get (void)
 	g_key_file_set_string(key_file, "object", "backend", "null");
 	g_key_file_set_string(key_file, "object", "component", "server");
 	g_key_file_set_string(key_file, "object", "path", "NULL");
-	g_key_file_set_string(key_file, "kv", "backend", "null2");
-	g_key_file_set_string(key_file, "kv", "component", "client");
-	g_key_file_set_string(key_file, "kv", "path", "NULL2");
-	g_key_file_set_string(key_file, "db", "backend", "null3");
+	g_key_file_set_string_list(key_file, "kv", "backend", kv_backends,2);
+	g_key_file_set_string_list(key_file, "kv", "component", kv_components, 2);
+	g_key_file_set_string_list(key_file, "kv", "path", kv_paths, 2);
+	g_key_file_set_string(key_file, "db", "backend", "null4");
 	g_key_file_set_string(key_file, "db", "component", "client");
-	g_key_file_set_string(key_file, "db", "path", "NULL3");
+	g_key_file_set_string(key_file, "db", "path", "NULL4");
 
 	configuration = j_configuration_new_for_data(key_file);
 	g_assert(configuration != NULL);
@@ -106,17 +111,24 @@ test_configuration_get (void)
 	g_assert_cmpstr(j_configuration_get_db_server(configuration, 1), ==, "host.local");
 	g_assert_cmpuint(j_configuration_get_db_server_count(configuration), ==, 2);
 
-	g_assert_cmpstr(j_configuration_get_object_backend(configuration), ==, "null");
-	g_assert_cmpstr(j_configuration_get_object_component(configuration), ==, "server");
-	g_assert_cmpstr(j_configuration_get_object_path(configuration), ==, "NULL");
+	g_assert_cmpuint(j_configuration_get_object_tier_count(configuration), ==, 1);
+	g_assert_cmpuint(j_configuration_get_kv_tier_count(configuration), ==, 2);
 
-	g_assert_cmpstr(j_configuration_get_kv_backend(configuration), ==, "null2");
-	g_assert_cmpstr(j_configuration_get_kv_component(configuration), ==, "client");
-	g_assert_cmpstr(j_configuration_get_kv_path(configuration), ==, "NULL2");
+	g_assert_cmpstr(j_configuration_get_object_backend(configuration, 0), ==, "null");
+	g_assert_cmpstr(j_configuration_get_object_component(configuration, 0), ==, "server");
+	g_assert_cmpstr(j_configuration_get_object_path(configuration, 0), ==, "NULL");
 
-	g_assert_cmpstr(j_configuration_get_db_backend(configuration), ==, "null3");
+	g_assert_cmpstr(j_configuration_get_kv_backend(configuration, 0), ==, "null2");
+	g_assert_cmpstr(j_configuration_get_kv_component(configuration, 0), ==, "client");
+	g_assert_cmpstr(j_configuration_get_kv_path(configuration, 0), ==, "NULL2");
+
+	g_assert_cmpstr(j_configuration_get_kv_backend(configuration, 1), ==, "null3");
+	g_assert_cmpstr(j_configuration_get_kv_component(configuration, 1), ==, "server");
+	g_assert_cmpstr(j_configuration_get_kv_path(configuration, 1), ==, "NULL3");
+
+	g_assert_cmpstr(j_configuration_get_db_backend(configuration), ==, "null4");
 	g_assert_cmpstr(j_configuration_get_db_component(configuration), ==, "client");
-	g_assert_cmpstr(j_configuration_get_db_path(configuration), ==, "NULL3");
+	g_assert_cmpstr(j_configuration_get_db_path(configuration), ==, "NULL4");
 
 	j_configuration_unref(configuration);
 


### PR DESCRIPTION
These commits enable JULEA to load and hold multiple backends in the config as welll as loading them in server and jcommon.

As the loading code in jcommon and server are very similar  the later commits merged the server code to the jcommon and uses that instead. 

This draft PR is only meant as a place to gather notes from feedback and ideas before providing it upstream.